### PR TITLE
Add support for defaultImageUrl()

### DIFF
--- a/resources/views/columns/stacked-image-column.blade.php
+++ b/resources/views/columns/stacked-image-column.blade.php
@@ -6,6 +6,13 @@
     $overlap = $getOverlap() ?? 1;
     $imageCount = 0;
 
+    $defaultImageUrl = $getDefaultImageUrl();
+
+    if ((! count($images)) && filled($defaultImageUrl)) {
+        $imagesWithPath = [null];
+    }
+
+
     $ring = match ($getRing()) {
         0 => 'ring-0',
         1 => 'ring-1',
@@ -43,13 +50,13 @@
                 },
             ])
         >
-            @foreach ($imagesWithPath as $path)
+            @foreach ($imagesWithPath as $image)
                 @php
                     $imageCount ++;
                 @endphp
                 
                 <img
-                    src="{{ $path }}"
+                    src="{{ filled($image) ? $getPath($image) : $defaultImageUrl }}"
                     style="
                         {!! $height !== null ? "height: {$height};" : null !!}
                         {!! $width !== null ? "width: {$width};" : null !!}

--- a/src/Columns/Concerns/HasRemaining.php
+++ b/src/Columns/Concerns/HasRemaining.php
@@ -12,7 +12,7 @@ trait HasRemaining
 
     protected string | Closure | null $remainingTextSize = null;
 
-    public function showRemaining(bool | Closure $condition = true, bool | Closure $showRemainingAfterStack = false, string | Closure | null $remainingTextSize = null): static
+    public function showRemaining(bool | Closure $condition = true, bool | Closure $showRemainingAfterStack = false, string | Closure $remainingTextSize = null): static
     {
         $this->shouldShowRemaining = $condition;
         $this->showRemainingAfterStack($showRemainingAfterStack);

--- a/src/Columns/StackedImageColumn.php
+++ b/src/Columns/StackedImageColumn.php
@@ -97,7 +97,7 @@ class StackedImageColumn extends ImageColumn
         return $this->evaluate($this->separator);
     }
 
-    public function getPath(string | null $image = null): ?string
+    public function getPath(string $image = null): ?string
     {
         $state = $image ?? $this->getState();
 


### PR DESCRIPTION
Fixes #4 adding support for Filament's [defaultImageUrl()](https://filamentphp.com/docs/2.x/tables/columns/image#adding-a-default-image-url). 